### PR TITLE
Adicionando Spring boot Actuator e OpenTelemetry javaagent, para monitoramento de Logs de eventos, metricas e telemetrias

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 ext {
     set('springCloudVersion', "2024.0.0")
+    set('otelVersion', "1.33.3")
 }
 
 repositories {
@@ -29,6 +30,9 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.cloud:spring-cloud-config-server'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly "io.opentelemetry.javaagent:opentelemetry-javaagent:${otelVersion}"
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -14,6 +14,10 @@ spec:
       name: config-service
       labels:
         app: config-service
+      annotations:
+        prometheus.io/scrap: "true"
+        prometheus.io/path: /actuator/prometheus
+        prometheus.io/port: "8888"
     spec:
       containers:
         - name: config-service
@@ -28,3 +32,15 @@ spec:
           env:
             - name: BPL_JVM_THREAD_COUNT
               value: "50"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 9001
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 9001
+            initialDelaySeconds: 5
+            periodSeconds: 15

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,22 @@ spring:
           timeout: 5
           clone-on-start: true
           force-pull: true
+
+logging:
+  pattern:
+    level: "%5p [${spring.application.name},%X{trace_id},%X{span_id}]"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
Adicionando Spring boot Actuator e OpenTelemetry javaagent, para monitoramento de Logs de eventos, metricas e telemetrias dos aplicativos, para obter uma melhor observabilidade e rastreamento de infraestrutura e funções do aplicativo desenvolvido. Utilizando a plataforma de observabilidade Grafana para gerenciar os sevirçoes de apoio, que são prometheus, Fluent-bit: para coletar os logs de eventos. Loki: para amarzena os eventos de logs coletado pelo fluent-bit. Tempo+OpenTelemetry para gerar arquivos de logs dentro do LOKI, mostrando o fluxo realizado para a requisição HTTP da aplicação e o fluxo realizado dentro dessa aplicação. Unica maneira até o momento de realizar monitoramento de aplicativos distribuidos.